### PR TITLE
add top_cor_gene.R

### DIFF
--- a/o2_scripts/top_cor_gene.R
+++ b/o2_scripts/top_cor_gene.R
@@ -1,0 +1,22 @@
+library(tidyverse)
+library(pheatmap)
+
+# Since you dont have the file (too large to push to github), we can try nonessential genes
+# but you can run anova.R to get essential_gene_data_nonzero.csv
+# gx <- data.table::fread("../essential_gene_data_nonzero.csv",drop = 1) # skip headers
+
+noness_gx_nonzero <- data.table::fread("../nonessential_gene_data_nonzero.csv",drop = 1) # skip headers
+
+
+percent_top_correlations <- 0.20 # what % of top correlated genes do we want to analyze?
+
+cors <- cor(noness_gx_nonzero[,3:ncol(noness_gx_nonzero)], method="s")
+
+cors[lower.tri(cors,diag=TRUE)] <- NA  #Prepare to drop duplicates and meaningless information
+cors <- as.data.frame(as.table(cors))  #Turn into a 3-column table
+cors <- na.omit(cors)  #Get rid of the junk we flagged above
+cors <- cors[order(-abs(cors$Freq)),]
+
+top_correlated_genes <- cors[1:ceiling(nrow(cors)*percent_top_correlations),]
+top_correlated_genes <- unique(unlist(as.list(top_correlated_genes[,1:2])))
+top_correlated_genes


### PR DESCRIPTION
I change the CorrelatedGenes.Rmd into top_cor_gene.R and tested on all non-essential genes which dont have zero expressions. The result appears to be that all non-essential genes are among the top correlated gene percentage.(20%) When I lower the percentage to 1%. The number of top correlated genes is 43. (137 in total)

And I recheck the sample.csv used in CorrelatedGenes.Rmd. It only has 7 genes and identifies 4 as top correlated. (using 20%) What percentage do you think we should use?

By the way, I am able to run top_cor_gene.R using nonessential_gene_data_nonzero.csv data on my computer. If you need the essential_gene_data_nonzero.csv data, you can run anova.R to get it. But I cannot push it to github since it exceeds to file size limit of 100Mb. But it also can be ran on my computer as well. 

